### PR TITLE
Fix the NDT test to no longer be CPU bound on high-bandwidth connections and also allow selection of the nearest MLab server

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
 						<a href="#" class="dropdown-toggle btn dropdown" data-toggle="dropdown" role="button" aria-expanded="false">Select Test Server <span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">
 							<li>
+								<a urn="" id="mlabns">Nearest MLab server</a>
+							</li>
+							<li>
 								<a urn="ndt.fh-luebeck.de">Fachhochschule L&uuml;beck - L&uuml;beck (Germany)</a>
 							</li>
 							<li>

--- a/js/meta_test.js
+++ b/js/meta_test.js
@@ -40,3 +40,25 @@ function startMetaTest() {
 	// Signalize end of transmission with empty TEST_MSG packet
 	sendNDTControlMsg(TEST_MSG, "");
 } 
+
+function processMetaMessage(header, contents) {
+        if (!clientState.versionCompatible) { return true; }
+        switch (header.charCodeAt(0)) {
+                case TEST_PREPARE:
+                        if (DEBUG) { writeToScreen('META: TEST_PREPARE', 'debug'); }
+                        return false;
+                case TEST_START:
+                        if (DEBUG) { writeToScreen('META: TEST_START', 'debug'); }
+                        startMetaTest();
+			metaProgress();
+			writeToScreen(displayMessages.sendingMetaInformation, 'details');
+                        return false;
+                case TEST_FINALIZE:
+                        if (DEBUG) { writeToScreen('META: TEST_FINALIZE', 'debug'); }
+			writeToScreen(displayMessages.stopping, 'details');
+                        return true;
+                default:
+                        if (DEBUG) { writeToScreen('Bad message type during META test: ' + header.charCodeAt(0), 'debug'); }
+                        return true;
+        }
+}

--- a/js/ndt_client.js
+++ b/js/ndt_client.js
@@ -18,6 +18,15 @@
 // var wsWwTest = false;
 
 $(document).ready(function() {
+	// Find the closest mlab server using mlab-ns.
+	$.ajax({
+		'url': 'http://mlab-ns.appspot.com/ndt',
+		'dataType': 'json',
+		'success': function (data) {
+			$('#mlabns').attr('urn', data.fqdn);
+		}
+	});
+
 	//hide Results on before test has been run
 
 	if (!DEBUG) {
@@ -57,8 +66,6 @@ $(document).ready(function() {
 		$("#StartBtn").prop('disabled', false);
 		var selText = $(this).text();
 		hostname = $(this).attr("urn");
-		// var hostUrn = $(this).attr("urn");
-		// console.log(hostUrn);
 		$(this).parents('.dropdown').find('.btn').html(selText + ' <span class="caret"></span>');
 	});
 
@@ -90,7 +97,7 @@ function showResults() {
 
 	// Printing property names and values using Array.forEach
 	Object.getOwnPropertyNames(clientResults).forEach(function(val, idx, array) {
-		if (clientResults[val].length > 0 && clientResults[val].indexOf("function") == -1) {
+		if (clientResults[val] !== null && clientResults[val].length !== undefined && clientResults[val].length > 0 && clientResults[val].indexOf("function") == -1) {
 			writeToScreen((val + ': ' + clientResults[val]), 'web100vars');
 		}
 	});

--- a/js/ndt_utils.js
+++ b/js/ndt_utils.js
@@ -31,9 +31,10 @@ function createTestBuffer(size) {
         if (c == '127') {
             c = '33';
         }
-        chars[i] = c++;
+        chars[i] = String.fromCharCode(c);
+        c++;
     }
-    return String.fromCharCode.apply(null, chars);
+    return chars.join('')
 }
 
 /**

--- a/js/s2c_test.js
+++ b/js/s2c_test.js
@@ -16,6 +16,7 @@
 "use strict";
 
 var s2cSocket = null;
+var s2ccallcounts = 0;
 
 //TODO Setup S2C Test as a Web Worker
 /**
@@ -24,17 +25,34 @@ var s2cSocket = null;
  * @return
  */
 function S2CSocket() {
+        // We have to use raw sockets here rather than TcpClient, because
+        // TcpClient does data conversion which causes us to become CPU bound.
+        chrome.sockets.tcp.create(
+                {
+                        bufferSize: 10000000
+                },
+                function(createInfo) {
+                        s2cSocket = createInfo.socketId;
+                        chrome.sockets.tcp.connect(
+                                s2cSocket,
+                                hostname,
+                                s2cPort,
+                                function () {
+                                        chrome.sockets.tcp.onReceive.addListener(receiveS2CStream);
+                                        onOpenS2C();
+                                }
+                        );
+                }
+        );
+}
 
-	s2cSocket = new TcpClient(hostname, s2cPort);
-	s2cSocket.connect(function() {
-
-		s2cSocket.addResponseListener(function(data) {
-			// onMessageC2S();
-			clientResults.s2cdataLength += data.length;
-		});
-
-		onOpenS2C();
-	});
+/**
+ * listens to sockets for arriving messages.
+ */
+function receiveS2CStream(receiveInfo) {
+        if (receiveInfo.socketId != s2cSocket) { return; }
+        clientResults.s2cdataLength += receiveInfo.data.byteLength;
+        s2ccallcounts++;
 }
 
 /**
@@ -53,12 +71,16 @@ function onOpenS2C() {
 /**
  * Description When the socket closes, get the time and calculate the test duration and
  * throughput value. Then send it to the server.
- * @method onCloseS2C
- * @param {} evt
+ * @method finishS2C
  * @return
  */
-function onCloseS2C() {
-
+function finishS2C() {
+        if (s2cSocket != null) {
+                chrome.sockets.tcp.onReceive.removeListener(receiveS2CStream);
+                chrome.sockets.tcp.disconnect(s2cSocket);
+                chrome.sockets.tcp.close(s2cSocket);
+                s2cSocket = null;
+        }
 	clientResults.s2cEndTime = new Date().getTime();
 	var S2C_TEST_DURATION_SECONDS = (clientResults.s2cEndTime - clientResults.s2cStartTime) / 1000;
 	var S2C_THROUGHPUT_VALUE = ((8 * clientResults.s2cdataLength) / 1000) / S2C_TEST_DURATION_SECONDS;
@@ -66,22 +88,10 @@ function onCloseS2C() {
 	sendNDTControlMsg(TEST_MSG, stringToArrayBuffer(S2C_THROUGHPUT_VALUE.toString()));
 	clientResults.clientDerivedDownloadSpd = parseFloat(S2C_THROUGHPUT_VALUE).toFixed(2);
 	if (DEBUG) {
-		writeToScreen('DISCONNECTED S2C', 'debug');
 		writeToScreen('<span style="color: blue;">S2C Length:' + clientResults.s2cdataLength + '</span>', 'debug');
 		writeToScreen('<span style="color: blue;">S2C Duration:' + S2C_TEST_DURATION_SECONDS + ' seconds </span>', 'debug');
 		writeToScreen('<span style="color: blue;">THROUGHPUT_VALUE:' + clientResults.clientDerivedDownloadSpd + ' </span>', 'debug');
 	}
-	// s2cSocket.disconnect(s2cSocket.socketId);
-}
-
-/**
- * Description Count all incoming bytes for later processing
- * @method onMessageS2C
- * @param {} evt
- * @return
- */
-function onMessageS2C(evt) {
-	clientResults.s2cdataLength += evt.data.byteLength;
 }
 
 /**
@@ -94,4 +104,38 @@ function onErrorS2C(evt) {
 	if (DEBUG) {
 		writeToScreen('<span style="color: red;">ERROR:' + evt.data + '</span>', 'debug');
 	}
+}
+
+var sentS2CDataRate = false;
+
+/**
+ * Description Respond to messages when an S2C test is occurring.
+ * @return true if the message was the last message in the test.
+ */
+function processS2CMessage(header, contents) {
+        if (!clientState.versionCompatible) { return true; }
+        switch (header.charCodeAt(0)) {
+                case TEST_PREPARE:
+                        if (DEBUG) { writeToScreen('S2C: TEST_PREPARE', 'debug'); }
+                        s2cPort = parseInt(contents);
+		        S2CSocket();
+			s2cProgress();
+			writeToScreen(displayMessages.runningInboundTest, 'details');
+                        return false;
+                case TEST_START:
+                        if (DEBUG) { writeToScreen('S2C: TEST_START', 'debug'); }
+                        setTimeout(finishS2C, 11000);
+                        // TEST_START is redundant for this test, as the server starts the test not the client.
+                        return false;
+                case TEST_MSG:
+                        if (DEBUG) { writeToScreen('S2C: TEST_MSG', 'debug'); }
+                        getResults(contents);
+                        return false;
+                case TEST_FINALIZE:
+                        if (DEBUG) { writeToScreen('S2C: TEST_FINALIZE', 'debug'); }
+                        return true;
+                default:
+                        if (DEBUG) { writeToScreen('Bad message type during s2ctest: ' + header.charCodeAt(0), 'debug'); }
+                        return true;
+        }
 }

--- a/js/tcp-client.js
+++ b/js/tcp-client.js
@@ -197,10 +197,6 @@ TcpClient.prototype._onReceiveError = function(info) {
  */
 TcpClient.prototype._onSendComplete = function(sendInfo) {
 	// log('onSendComplete');
-	//Only count the packages sent during the c2s test
-	if ((clientState.currentTest == TESTTYPE_C2S) && (clientResults.c2sEndTime == null)) {
-		clientResults.c2stestDatasent += PREDEFINED_BUFFER_SIZE;
-	}
 	// Call sent callback.
 	if (this.callbacks.sent) {
 		this.callbacks.sent(sendInfo);


### PR DESCRIPTION
Fix the NDT test to no longer be CPU bound on high-bandwidth connections and also allow selection of the nearest MLab server.

The NDT test is no longer CPU bound on high bandwidth connections.
The parsing/test logic has been cleaned up.
There is now an option to select the nearest MLab server.
